### PR TITLE
カード情報トークン化に対応

### DIFF
--- a/lib/sphy_gmo/card.rb
+++ b/lib/sphy_gmo/card.rb
@@ -6,12 +6,10 @@ module SphyGmo
       raise SphyGmo::APIError.new(e)
     end
 
-    def self.save!(member_id: ,card_no: ,holder_name: ,expire: ,card_seq: nil ,default_flag: ,seq_mode: )
+    def self.save!(member_id: ,token: ,card_seq: nil ,default_flag: ,seq_mode: )
       SphyGmo.gmo_site.save_card({
           member_id: member_id,
-          card_no: card_no,
-          holder_name: holder_name,
-          expire: expire,
+          token: token,
           card_seq: card_seq,
           default_flag: default_flag,
           seq_mode: seq_mode


### PR DESCRIPTION
# 概要
カード情報トークン化サービスに対応するために`token`を追加

# 受入基準
- [ ] GMOペイメントゲートウェイの会員情報がトークンとともに登録されている
  